### PR TITLE
Fixed a few issues causing this playbook to not work

### DIFF
--- a/roles/preconfig/tasks/main.yml
+++ b/roles/preconfig/tasks/main.yml
@@ -41,3 +41,6 @@
   script: "{{ scripts }}/ntpset"
   become: yes
   # TODO check result
+  
+ - name: restart ntp
+  service: name=ntp state=restarted

--- a/roles/preconfig/tasks/main.yml
+++ b/roles/preconfig/tasks/main.yml
@@ -16,12 +16,6 @@
   become: yes
 # TODO disable login
 
-- name: Use the trusted NTP
-  when: use_trusted_ntp
-  script: "{{ scripts }}/ntpset"
-  become: yes
-  # TODO check result
-
 - name: Update apt
   apt:
     upgrade: yes
@@ -38,4 +32,12 @@
       - libssl-dev
       - libffi-dev
       - jq
+      - ntp
+      - ntpstat
   become: yes
+
+- name: Use the trusted NTP
+  when: use_trusted_ntp
+  script: "{{ scripts }}/ntpset"
+  become: yes
+  # TODO check result

--- a/scripts/ntpset
+++ b/scripts/ntpset
@@ -1,6 +1,5 @@
 #!/bin/bash
 timedatectl set-ntp no
-apt-get install -y ntp ntpstat
 sed -i 's/pool 0.ubuntu.pool.ntp.org iburst/server 0.de.pool.ntp.org iburst/' /etc/ntp.conf
 sed -i 's/pool 1.ubuntu.pool.ntp.org iburst/server 1.de.pool.ntp.org iburst/' /etc/ntp.conf
 sed -i 's/pool 2.ubuntu.pool.ntp.org iburst/server 2.de.pool.ntp.org iburst/' /etc/ntp.conf

--- a/scripts/ntpset
+++ b/scripts/ntpset
@@ -4,4 +4,3 @@ sed -i 's/pool 0.ubuntu.pool.ntp.org iburst/server 0.de.pool.ntp.org iburst/' /e
 sed -i 's/pool 1.ubuntu.pool.ntp.org iburst/server 1.de.pool.ntp.org iburst/' /etc/ntp.conf
 sed -i 's/pool 2.ubuntu.pool.ntp.org iburst/server 2.de.pool.ntp.org iburst/' /etc/ntp.conf
 sed -i 's/pool 3.ubuntu.pool.ntp.org iburst/server 3.de.pool.ntp.org iburst/' /etc/ntp.conf
-/etc/init.d/ntp restart


### PR DESCRIPTION
Not sure if you tested this playbook before and if it worked for you but it didn't for me (on Ubuntu 18.04) so I fixed few issues.

1. Moved order of tasks in preconfig. Update apt needs to be executed before "Use trusted NTP" because in the script you executing tries to install some apt packages but without executing apt update prior to it, it can't.
2. Since I moved the use trusted NTP to the end of the preconfid task I also moved "apt install ntp ntpstat" into "install build requirements" list in the task - makes more sense there
3. ntp restart at the end of the "use trusted ntp" script causes ansible to fail (since it drops ssh connection) so I added ntp restart as a task in preconfig and removed it from the script (this way ansible can handle ssh dropout)

Tested and working on Ubuntu 18.04